### PR TITLE
If hiccup is a function call the function until it returns hiccup data

### DIFF
--- a/src/main/react_testing_library_cljs/reagent/render.cljs
+++ b/src/main/react_testing_library_cljs/reagent/render.cljs
@@ -11,5 +11,7 @@
                                   (.setAttribute "id" test-container-id))))
 
 (defn render! [hiccup]
-  (testing-library/render (r/as-element hiccup)
-                          #js {:container (testing-container)}))
+  (if (fn? hiccup)
+    (render! (hiccup))
+    (testing-library/render (r/as-element hiccup)
+                            #js {:container (testing-container)})))

--- a/src/main/react_testing_library_cljs/reagent/render.cljs
+++ b/src/main/react_testing_library_cljs/reagent/render.cljs
@@ -5,7 +5,7 @@
 (def test-container-id "test-container")
 
 (defn testing-container []
-  (some-> (js/document.getElementById test-container-id) .remove)
+  (set! (.-innerHTML js/document.body) "")
   (js/document.body.appendChild (doto (js/document.createElement "div")
                                   (.setAttribute "data-testid" test-container-id)
                                   (.setAttribute "id" test-container-id))))


### PR DESCRIPTION
It is common to write hiccup components like this 
```
(defn notifications-dropdown []
  (fn []
      hiccup))

;; where hiccup is a data structure like [:div ] 
```
whereas render! expects the pure data structure. 